### PR TITLE
missing BLARGG_EXPORT macros actually added to gme.h

### DIFF
--- a/gme/gme.h
+++ b/gme/gme.h
@@ -4,6 +4,8 @@
 #ifndef GME_H
 #define GME_H
 
+#include "blargg_source.h"
+
 #ifdef __cplusplus
 	extern "C" {
 #endif
@@ -18,35 +20,35 @@ typedef struct Music_Emu Music_Emu;
 /******** Basic operations ********/
 
 /* Create emulator and load game music file/data into it. Sets *out to new emulator. */
-gme_err_t gme_open_file( const char path [], Music_Emu** out, int sample_rate );
+BLARGG_EXPORT gme_err_t gme_open_file( const char path [], Music_Emu** out, int sample_rate );
 
 /* Number of tracks available */
-int gme_track_count( Music_Emu const* );
+BLARGG_EXPORT int gme_track_count( Music_Emu const* );
 
 /* Start a track, where 0 is the first track */
-gme_err_t gme_start_track( Music_Emu*, int index );
+BLARGG_EXPORT gme_err_t gme_start_track( Music_Emu*, int index );
 
 /* Generate 'count' 16-bit signed samples info 'out'. Output is in stereo. */
-gme_err_t gme_play( Music_Emu*, int count, short out [] );
+BLARGG_EXPORT gme_err_t gme_play( Music_Emu*, int count, short out [] );
 
 /* Finish using emulator and free memory */
-void gme_delete( Music_Emu* );
+BLARGG_EXPORT void gme_delete( Music_Emu* );
 
 
 /******** Track position/length ********/
 
 /* Set time to start fading track out. Once fade ends track_ended() returns true.
 Fade time can be changed while track is playing. */
-void gme_set_fade( Music_Emu*, int start_msec );
+BLARGG_EXPORT void gme_set_fade( Music_Emu*, int start_msec );
 
 /* True if a track has reached its end */
-int gme_track_ended( Music_Emu const* );
+BLARGG_EXPORT int gme_track_ended( Music_Emu const* );
 
 /* Number of milliseconds (1000 = one second) played since beginning of track */
-int gme_tell( Music_Emu const* );
+BLARGG_EXPORT int gme_tell( Music_Emu const* );
 
 /* Seek to new time in track. Seeking backwards or far forward can take a while. */
-gme_err_t gme_seek( Music_Emu*, int msec );
+BLARGG_EXPORT gme_err_t gme_seek( Music_Emu*, int msec );
 
 
 /******** Informational ********/
@@ -57,22 +59,22 @@ enum { gme_info_only = -1 };
 
 /* Most recent warning string, or NULL if none. Clears current warning after returning.
 Warning is also cleared when loading a file and starting a track. */
-const char* gme_warning( Music_Emu* );
+BLARGG_EXPORT const char* gme_warning( Music_Emu* );
 
 /* Load m3u playlist file (must be done after loading music) */
-gme_err_t gme_load_m3u( Music_Emu*, const char path [] );
+BLARGG_EXPORT gme_err_t gme_load_m3u( Music_Emu*, const char path [] );
 
 /* Clear any loaded m3u playlist and any internal playlist that the music format
 supports (NSFE for example). */
-void gme_clear_playlist( Music_Emu* );
+BLARGG_EXPORT void gme_clear_playlist( Music_Emu* );
 
 /* Gets information for a particular track (length, name, author, etc.).
 Must be freed after use. */
 typedef struct gme_info_t gme_info_t;
-gme_err_t gme_track_info( Music_Emu const*, gme_info_t** out, int track );
+BLARGG_EXPORT gme_err_t gme_track_info( Music_Emu const*, gme_info_t** out, int track );
 
 /* Frees track information */
-void gme_free_info( gme_info_t* );
+BLARGG_EXPORT void gme_free_info( gme_info_t* );
 
 struct gme_info_t
 {
@@ -104,28 +106,28 @@ struct gme_info_t
 
 /* Adjust stereo echo depth, where 0.0 = off and 1.0 = maximum. Has no effect for
 GYM, SPC, and Sega Genesis VGM music */
-void gme_set_stereo_depth( Music_Emu*, double depth );
+BLARGG_EXPORT void gme_set_stereo_depth( Music_Emu*, double depth );
 
 /* Disable automatic end-of-track detection and skipping of silence at beginning
 if ignore is true */
-void gme_ignore_silence( Music_Emu*, int ignore );
+BLARGG_EXPORT void gme_ignore_silence( Music_Emu*, int ignore );
 
 /* Adjust song tempo, where 1.0 = normal, 0.5 = half speed, 2.0 = double speed.
 Track length as returned by track_info() assumes a tempo of 1.0. */
-void gme_set_tempo( Music_Emu*, double tempo );
+BLARGG_EXPORT void gme_set_tempo( Music_Emu*, double tempo );
 
 /* Number of voices used by currently loaded file */
-int gme_voice_count( Music_Emu const* );
+BLARGG_EXPORT int gme_voice_count( Music_Emu const* );
 
 /* Name of voice i, from 0 to gme_voice_count() - 1 */
-const char* gme_voice_name( Music_Emu const*, int i );
+BLARGG_EXPORT const char* gme_voice_name( Music_Emu const*, int i );
 
 /* Mute/unmute voice i, where voice 0 is first voice */
-void gme_mute_voice( Music_Emu*, int index, int mute );
+BLARGG_EXPORT void gme_mute_voice( Music_Emu*, int index, int mute );
 
 /* Set muting state of all voices at once using a bit mask, where -1 mutes all
 voices, 0 unmutes them all, 0x01 mutes just the first voice, etc. */
-void gme_mute_voices( Music_Emu*, int muting_mask );
+BLARGG_EXPORT void gme_mute_voices( Music_Emu*, int muting_mask );
 
 /* Frequency equalizer parameters (see gme.txt) */
 typedef struct gme_equalizer_t
@@ -137,13 +139,13 @@ typedef struct gme_equalizer_t
 } gme_equalizer_t;
 
 /* Get current frequency equalizater parameters */
-void gme_equalizer( Music_Emu const*, gme_equalizer_t* out );
+BLARGG_EXPORT void gme_equalizer( Music_Emu const*, gme_equalizer_t* out );
 
 /* Change frequency equalizer parameters */
-void gme_set_equalizer( Music_Emu*, gme_equalizer_t const* eq );
+BLARGG_EXPORT void gme_set_equalizer( Music_Emu*, gme_equalizer_t const* eq );
 
 /* Enables/disables most accurate sound emulation options */
-void gme_enable_accuracy( Music_Emu*, int enabled );
+BLARGG_EXPORT void gme_enable_accuracy( Music_Emu*, int enabled );
 
 
 /******** Game music types ********/
@@ -166,17 +168,17 @@ extern const gme_type_t
 	gme_vgz_type;
 
 /* Type of this emulator */
-gme_type_t gme_type( Music_Emu const* );
+BLARGG_EXPORT gme_type_t gme_type( Music_Emu const* );
 
 /* Pointer to array of all music types, with NULL entry at end. Allows a player linked
 to this library to support new music types without having to be updated. */
-gme_type_t const* gme_type_list();
+BLARGG_EXPORT gme_type_t const* gme_type_list();
 
 /* Name of game system for this music file type */
-const char* gme_type_system( gme_type_t );
+BLARGG_EXPORT const char* gme_type_system( gme_type_t );
 
 /* True if this music file type supports multiple tracks */
-int gme_type_multitrack( gme_type_t );
+BLARGG_EXPORT int gme_type_multitrack( gme_type_t );
 
 
 /******** Advanced file loading ********/
@@ -185,50 +187,50 @@ int gme_type_multitrack( gme_type_t );
 extern const char* const gme_wrong_file_type;
 
 /* Same as gme_open_file(), but uses file data already in memory. Makes copy of data. */
-gme_err_t gme_open_data( void const* data, long size, Music_Emu** out, int sample_rate );
+BLARGG_EXPORT gme_err_t gme_open_data( void const* data, long size, Music_Emu** out, int sample_rate );
 
 /* Determine likely game music type based on first four bytes of file. Returns
 string containing proper file suffix (i.e. "NSF", "SPC", etc.) or "" if
 file header is not recognized. */
-const char* gme_identify_header( void const* header );
+BLARGG_EXPORT const char* gme_identify_header( void const* header );
 
 /* Get corresponding music type for file path or extension passed in. */
-gme_type_t gme_identify_extension( const char path_or_extension [] );
+BLARGG_EXPORT gme_type_t gme_identify_extension( const char path_or_extension [] );
 
 /* Determine file type based on file's extension or header (if extension isn't recognized).
 Sets *type_out to type, or 0 if unrecognized or error. */
-gme_err_t gme_identify_file( const char path [], gme_type_t* type_out );
+BLARGG_EXPORT gme_err_t gme_identify_file( const char path [], gme_type_t* type_out );
 
 /* Create new emulator and set sample rate. Returns NULL if out of memory. If you only need
 track information, pass gme_info_only for sample_rate. */
-Music_Emu* gme_new_emu( gme_type_t, int sample_rate );
+BLARGG_EXPORT Music_Emu* gme_new_emu( gme_type_t, int sample_rate );
 
 /* Load music file into emulator */
-gme_err_t gme_load_file( Music_Emu*, const char path [] );
+BLARGG_EXPORT gme_err_t gme_load_file( Music_Emu*, const char path [] );
 
 /* Load music file from memory into emulator. Makes a copy of data passed. */
-gme_err_t gme_load_data( Music_Emu*, void const* data, long size );
+BLARGG_EXPORT gme_err_t gme_load_data( Music_Emu*, void const* data, long size );
 
 /* Load music file using custom data reader function that will be called to
 read file data. Most emulators load the entire file in one read call. */
 typedef gme_err_t (*gme_reader_t)( void* your_data, void* out, int count );
-gme_err_t gme_load_custom( Music_Emu*, gme_reader_t, long file_size, void* your_data );
+BLARGG_EXPORT gme_err_t gme_load_custom( Music_Emu*, gme_reader_t, long file_size, void* your_data );
 
 /* Load m3u playlist file from memory (must be done after loading music) */
-gme_err_t gme_load_m3u_data( Music_Emu*, void const* data, long size );
+BLARGG_EXPORT gme_err_t gme_load_m3u_data( Music_Emu*, void const* data, long size );
 
 
 /******** User data ********/
 
 /* Set/get pointer to data you want to associate with this emulator.
 You can use this for whatever you want. */
-void  gme_set_user_data( Music_Emu*, void* new_user_data );
-void* gme_user_data( Music_Emu const* );
+BLARGG_EXPORT void  gme_set_user_data( Music_Emu*, void* new_user_data );
+BLARGG_EXPORT void* gme_user_data( Music_Emu const* );
 
 /* Register cleanup function to be called when deleting emulator, or NULL to
 clear it. Passes user_data to cleanup function. */
 typedef void (*gme_user_cleanup_t)( void* user_data );
-void gme_set_user_cleanup( Music_Emu*, gme_user_cleanup_t func );
+BLARGG_EXPORT void gme_set_user_cleanup( Music_Emu*, gme_user_cleanup_t func );
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
a comment on one of the most recent commits indicates that BLARGG_EXPORT macros should already be in gme.h but they're not there and gme.h is untouched in that commit

This change fixes gme.h