### PR TITLE
Fix build with clang

### DIFF
--- a/gme/Gbs_Emu.h
+++ b/gme/Gbs_Emu.h
@@ -41,7 +41,7 @@ public:
 	
 public:
 	// deprecated
-	Music_Emu::load;
+	using Music_Emu::load;
 	blargg_err_t load( header_t const& h, Data_Reader& in ) // use Remaining_Reader
 			{ return load_remaining_( &h, sizeof h, in ); }
 

--- a/gme/Gym_Emu.h
+++ b/gme/Gym_Emu.h
@@ -34,7 +34,7 @@ public:
 	
 public:
 	// deprecated
-	Music_Emu::load;
+	using Music_Emu::load;
 	blargg_err_t load( header_t const& h, Data_Reader& in ) // use Remaining_Reader
 			{ return load_remaining_( &h, sizeof h, in ); }
 	enum { gym_rate = 60 }; 

--- a/gme/Music_Emu.h
+++ b/gme/Music_Emu.h
@@ -58,7 +58,7 @@ public:
 	void ignore_silence( bool disable = true );
 	
 	// Info for current track
-	Gme_File::track_info;
+	using Gme_File::track_info;
 	blargg_err_t track_info( track_info_t* out ) const;
 	
 // Sound customization

--- a/gme/Nsf_Emu.h
+++ b/gme/Nsf_Emu.h
@@ -44,7 +44,7 @@ public:
 	
 public:
 	// deprecated
-	Music_Emu::load;
+	using Music_Emu::load;
 	blargg_err_t load( header_t const& h, Data_Reader& in ) // use Remaining_Reader
 			{ return load_remaining_( &h, sizeof h, in ); }
 

--- a/gme/Nsfe_Emu.h
+++ b/gme/Nsfe_Emu.h
@@ -46,7 +46,7 @@ public:
 public:
 	// deprecated
 	struct header_t { char tag [4]; };
-	Music_Emu::load;
+	using Music_Emu::load;
 	blargg_err_t load( header_t const& h, Data_Reader& in ) // use Remaining_Reader
 			{ return load_remaining_( &h, sizeof h, in ); }
 	void disable_playlist( bool = true ); // use clear_playlist()

--- a/gme/Spc_Emu.h
+++ b/gme/Spc_Emu.h
@@ -48,7 +48,7 @@ public:
 	
 public:
 	// deprecated
-	Music_Emu::load;
+	using Music_Emu::load;
 	blargg_err_t load( header_t const& h, Data_Reader& in ) // use Remaining_Reader
 			{ return load_remaining_( &h, sizeof h, in ); }
 	byte const* trailer() const; // use track_info()

--- a/gme/Vgm_Emu.h
+++ b/gme/Vgm_Emu.h
@@ -51,7 +51,7 @@ public:
 	
 public:
 	// deprecated
-	Music_Emu::load;
+	using Music_Emu::load;
 	blargg_err_t load( header_t const& h, Data_Reader& in ) // use Remaining_Reader
 			{ return load_remaining_( &h, sizeof h, in ); }
 	byte const* gd3_data( int* size_out = 0 ) const; // use track_info()


### PR DESCRIPTION
Fix Clang error:
"ISO C++11 does not allow access declarations; use using declarations instead"